### PR TITLE
Strict encoding of tuple and array types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Read the Docs](https://img.shields.io/readthedocs/eth-stdlib)](https://eth-stdlib.readthedocs.io/en/latest/)
 [![PyPI](https://img.shields.io/pypi/v/eth-stdlib)](https://pypi.org/project/eth-stdlib/)
 
-A collection of pure python libraries for developers building on the EVM.
+The Ethereum Standard Library is a collection of libraries for developers building on the EVM.
 
 ## Installation
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 Welcome to eth-stdlib's documentation!
 ======================================
 
-The Ethereum Standard Library is a collection of pure python libraries for developers building on the EVM.
+The Ethereum Standard Library is a collection of libraries for developers building on the EVM.
 The intention is to have a single repository of data structures and utilities which is easy to grok and just as
 easy to install as a dependency.
 

--- a/src/eth/codecs/abi/encoder.py
+++ b/src/eth/codecs/abi/encoder.py
@@ -104,7 +104,7 @@ class Encoder:
             EncodeError: If the value can't be encoded.
         """
         try:
-            assert isinstance(value, (list, tuple)), "Value is not a list or tuple type"
+            assert isinstance(value, list), "Value is not a list type"
             if node.length is not None:
                 assert len(value) == node.length, f"Expected value of size {node.length}"
         except AssertionError as e:
@@ -293,7 +293,7 @@ class Encoder:
         """
         try:
             # validate value is a list or tuple of appropriate size
-            assert isinstance(value, (list, tuple)), "Value is not a list or tuple type"
+            assert isinstance(value, tuple), "Value is not a tuple type"
             assert len(node.ctypes) == len(value), f"Expected value of size {len(node.ctypes)}"
         except AssertionError as e:
             raise EncodeError(str(node), value, e.args[0])

--- a/src/eth/codecs/abi/encoder.py
+++ b/src/eth/codecs/abi/encoder.py
@@ -104,7 +104,7 @@ class Encoder:
             EncodeError: If the value can't be encoded.
         """
         try:
-            assert isinstance(value, list), "Value is not a list type"
+            assert isinstance(value, list), "Value is not an instance of type 'list'"
             if node.length is not None:
                 assert len(value) == node.length, f"Expected value of size {node.length}"
         except AssertionError as e:
@@ -293,7 +293,7 @@ class Encoder:
         """
         try:
             # validate value is a list or tuple of appropriate size
-            assert isinstance(value, tuple), "Value is not a tuple type"
+            assert isinstance(value, tuple), "Value is not an instance of type 'tuple'"
             assert len(node.ctypes) == len(value), f"Expected value of size {len(node.ctypes)}"
         except AssertionError as e:
             raise EncodeError(str(node), value, e.args[0])

--- a/src/eth/codecs/utils.py
+++ b/src/eth/codecs/utils.py
@@ -1,10 +1,8 @@
-import functools
 import string
 
 from sha3 import keccak_256 as keccak256
 
 
-@functools.singledispatch
 def checksum_encode(addr: str | bytes) -> str:
     """Checksum encode an address.
 
@@ -20,14 +18,16 @@ def checksum_encode(addr: str | bytes) -> str:
         TypeError: If ``addr`` argument is not an instance of ``str`` or ``bytes``.
         ValueError: If ``addr`` contains non-hexadecimal characters or is not the proper length.
     """
-    raise TypeError(
-        f"Invalid argument type, expected 'str' or 'bytes' got: {type(addr).__qualname__}"
-    )
+    if isinstance(addr, bytes):
+        hexval = addr.hex()
+    elif isinstance(addr, str):
+        hexval = addr.lower().removeprefix("0x")
+    else:
+        raise TypeError(
+            f"Invalid argument type, expected 'str' or 'bytes' got: {type(addr).__qualname__}"
+        )
 
-
-@checksum_encode.register
-def _(addr: str) -> str:
-    if len(hexval := addr.lower().removeprefix("0x")) != 40:
+    if len(hexval) != 40:
         raise ValueError("Invalid value length")
     elif not set(hexval) < set(string.hexdigits):
         raise ValueError("Invalid hexadecimal characters")
@@ -38,8 +38,3 @@ def _(addr: str) -> str:
         buffer += char.upper() if int(nibble, 16) > 7 else char
 
     return "0x" + buffer
-
-
-@checksum_encode.register
-def _(addr: bytes) -> str:
-    return checksum_encode(addr.hex())

--- a/tests/eth/codecs/abi/test_encode.py
+++ b/tests/eth/codecs/abi/test_encode.py
@@ -156,7 +156,7 @@ def test_encoding_invalid_address_value_raises():
 
 
 def test_encoding_invalid_array_value_raises():
-    with pytest.raises(EncodeError, match="Value is not a list or tuple type"):
+    with pytest.raises(EncodeError, match="Value is not a list type"):
         encode("uint256[]", {})
 
     with pytest.raises(EncodeError, match="Expected value of size 3"):
@@ -201,7 +201,7 @@ def test_encoding_invalid_string_value_raises():
 
 
 def test_encoding_invalid_tuple_value_raises():
-    with pytest.raises(EncodeError, match="Value is not a list or tuple type"):
+    with pytest.raises(EncodeError, match="Value is not a tuple type"):
         encode("(string)", set(["", "Hello"]))
 
     with pytest.raises(EncodeError, match="Expected value of size 1"):

--- a/tests/eth/codecs/abi/test_encode.py
+++ b/tests/eth/codecs/abi/test_encode.py
@@ -156,7 +156,7 @@ def test_encoding_invalid_address_value_raises():
 
 
 def test_encoding_invalid_array_value_raises():
-    with pytest.raises(EncodeError, match="Value is not a list type"):
+    with pytest.raises(EncodeError, match="Value is not an instance of type 'list'"):
         encode("uint256[]", {})
 
     with pytest.raises(EncodeError, match="Expected value of size 3"):
@@ -201,7 +201,7 @@ def test_encoding_invalid_string_value_raises():
 
 
 def test_encoding_invalid_tuple_value_raises():
-    with pytest.raises(EncodeError, match="Value is not a tuple type"):
+    with pytest.raises(EncodeError, match="Value is not an instance of type 'tuple'"):
         encode("(string)", set(["", "Hello"]))
 
     with pytest.raises(EncodeError, match="Expected value of size 1"):


### PR DESCRIPTION
Arrays need to be lists, and tuples (structs) need to be tuples.