### PR TITLE
fix: allow decoding tuples with trailing bytes

### DIFF
--- a/src/eth/codecs/abi/decoder.py
+++ b/src/eth/codecs/abi/decoder.py
@@ -293,12 +293,8 @@ class Decoder:
         """
         size = sum((elem.width for elem in node.ctypes))
         # value size should be >= the sum of the length of its components
-        if node.is_dynamic and len(value) < size:
+        if len(value) < size:
             raise DecodeError(str(node), value, "Value length is less than expected")
-        elif not node.is_dynamic and len(value) != size:
-            raise DecodeError(
-                str(node), value, f"Value length is not the expected size of {size} bytes"
-            )
 
         pos, raw_head = 0, []
         for ctyp in node.ctypes:

--- a/tests/eth/codecs/abi/test_decode.py
+++ b/tests/eth/codecs/abi/test_decode.py
@@ -25,6 +25,11 @@ def test_decoding(value):
     assert decode(typestr, encode(typestr, val)) == val
 
 
+def test_decoding_tuple_trailing_bytes():
+    value = b"\x00" * 33
+    assert decode("(uint256)", value) == (0,)
+
+
 def test_decoding_disable_checksum():
     value = b"\x00" * 12 + bytes.fromhex("Cd2a3d9f938e13Cd947eC05ABC7fe734df8DD826")
     assert decode("address", value, checksum=False) == "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826"
@@ -77,7 +82,7 @@ def test_decode_integer_and_fixed_raises_for_invalid_value(typestr):
 
 
 def test_decode_tuple_raises_for_invalid_value():
-    with pytest.raises(DecodeError, match="expected size of 32 bytes"):
+    with pytest.raises(DecodeError, match="Value length is less than expected"):
         decode("(uint256)", b"")
 
     with pytest.raises(DecodeError, match="Value length is less than expected"):

--- a/tests/eth/codecs/abi/test_decode.py
+++ b/tests/eth/codecs/abi/test_decode.py
@@ -25,7 +25,8 @@ def test_decoding(value):
     assert decode(typestr, encode(typestr, val)) == val
 
 
-def test_decoding_tuple_trailing_bytes():
+def test_decode_tuple_trailing_bytes():
+    # should be able to decode a tuple even with trailing bytes
     value = b"\x00" * 33
     assert decode("(uint256)", value) == (0,)
 


### PR DESCRIPTION
it's valid ABI


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

**Software Configuration(s)**: (optional)

* Operating System:
* Software version:
* Branch:
* Toolchain version:
* SDK version:

## Reviews

Please identify two developers to review this change

- [ ] @personA
- [ ] @personB

## Checklist: (Please delete options that are not relevant)

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
